### PR TITLE
generate the iworld factory using world/iworld.sol vs iworld.sol

### DIFF
--- a/packages/cli/src/utils/worldtypes.ts
+++ b/packages/cli/src/utils/worldtypes.ts
@@ -8,7 +8,9 @@ import { runTypeChain } from "typechain";
 export async function worldtypes() {
   const cwd = process.cwd();
   const forgeOurDir = await getOutDirectory();
-  const IWorldPath = path.join(process.cwd(), forgeOurDir, "IWorld.sol/IWorld.json");
+  // Curtis changed this IWorldPath after we migrated to Yarn since we had a naming conflict (two IWorld.sol files): https://github.com/tenetxyz/voxel-aw/pull/45/files
+  // const IWorldPath = path.join(process.cwd(), forgeOurDir, "IWorld.sol/IWorld.json");
+  const IWorldPath = path.join(process.cwd(), forgeOurDir, "world/IWorld.sol/IWorld.json");
   console.log(cwd);
   console.log(IWorldPath);
 


### PR DESCRIPTION
Since there are two IWorld interfaces in the code, foundry tries to disambiguate them by placing one of the IWorld interfaces in `world/IWorld.sol/`. So I just changed where the TypeChain looks so that it generates the right typscript bindings for the world contract we care about.