### PR TITLE
Rename iworld

### DIFF
--- a/integration-sandbox/packages/test/setup.ts
+++ b/integration-sandbox/packages/test/setup.ts
@@ -18,7 +18,7 @@ export function startAnvil(port: number): ExecaChildProcess {
 }
 
 export function deployContracts(rpc: string): ExecaChildProcess {
-  const deploymentProcess = execa("pnpm", ["mud", "deploy", "--rpc", rpc], { cwd: "../contracts", stdio: "pipe" });
+  const deploymentProcess = execa("yarn", ["mud", "deploy", "--rpc", rpc], { cwd: "../contracts", stdio: "pipe" });
   deploymentProcess.stdout?.on("data", (data) => {
     console.log(chalk.blueBright("[mud deploy]:"), data.toString());
   });

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -36,6 +36,7 @@ const commandModule: CommandModule<DeployOptions, DeployOptions> = {
   },
 
   async handler(args) {
+    args.debug = true;
     try {
       await deployHandler(args);
     } catch (error: any) {

--- a/packages/cli/src/mud.ts
+++ b/packages/cli/src/mud.ts
@@ -23,7 +23,7 @@ yargs(hideBin(process.argv))
     console.error(chalk.red(msg));
     if (msg.includes("Missing required argument")) {
       console.log(
-        chalk.yellow(`Run 'pnpm mud ${process.argv[2]} --help' for a list of available and required arguments.`)
+        chalk.yellow(`Run 'yarn mud ${process.argv[2]} --help' for a list of available and required arguments.`)
       );
     }
     console.log("");

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -554,7 +554,7 @@ export async function deploy(
     if (!feeData.lastBaseFeePerGas) throw new MUDError("Can not fetch lastBaseFeePerGas from RPC");
     if (!feeData.lastBaseFeePerGas.eq(0) && (await signer.getBalance()).eq(0)) {
       throw new MUDError(`Attempting to deploy to a chain with non-zero base fee with an account that has no balance.
-If you're deploying to the Lattice testnet, you can fund your account by running 'pnpm mud faucet --address ${await signer.getAddress()}'`);
+If you're deploying to the Lattice testnet, you can fund your account by running 'yarn mud faucet --address ${await signer.getAddress()}'`);
     }
 
     // Set the priority fee to 0 for development chains with no base fee, to allow transactions from unfunded wallets

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -495,13 +495,22 @@ export async function deploy(
     const functionName = `${func as string}(${args.map((arg) => `'${arg}'`).join(",")})`;
     try {
       const gasLimit = await contract.estimateGas[func].apply(null, args);
-      console.log(chalk.gray(`executing transaction: ${functionName} with nonce ${nonce}`));
+      console.log(chalk.gray(`[2] executing transaction: ${functionName} with nonce ${nonce}`));
       const txPromise = contract[func]
         .apply(null, [...args, { gasLimit, nonce: nonce++, maxPriorityFeePerGas, maxFeePerGas }])
         .then((tx: any) => (confirmations === 0 ? tx : tx.wait(confirmations)));
       promises.push(txPromise);
+      // console.log("txpromise", txPromise.toString())
+      // const a = await txPromise;
+      // console.log(a);
+      // console.log("wait")
+      // console.log(await a.wait());
       return txPromise;
     } catch (error: any) {
+      console.log(
+        "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+      );
+      console.log("error", error);
       if (debug) console.error(error);
       if (retryCount === 0 && error?.message.includes("transaction already imported")) {
         // If the deployment failed because the transaction was already imported,

--- a/packages/cli/src/utils/worldtypes.ts
+++ b/packages/cli/src/utils/worldtypes.ts
@@ -9,6 +9,8 @@ export async function worldtypes() {
   const cwd = process.cwd();
   const forgeOurDir = await getOutDirectory();
   const IWorldPath = path.join(process.cwd(), forgeOurDir, "IWorld.sol/IWorld.json");
+  console.log(cwd);
+  console.log(IWorldPath);
 
   await runTypeChain({
     cwd,

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -112,8 +112,9 @@ export async function anvil(args: string[]): Promise<string> {
 async function execLog(command: string, args: string[], options?: Options<string>): Promise<string> {
   const commandString = `${command} ${args.join(" ")}`;
   try {
-    console.log(chalk.gray(`running "${commandString}"`));
+    console.log(chalk.gray(`[3] running "${commandString}"`));
     const { stdout } = await execa(command, args, { stdout: "pipe", stderr: "pipe", ...options });
+    console.log(`execute result ${command}`, stdout);
     return stdout;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/packages/create-mud/src/cli.ts
+++ b/packages/create-mud/src/cli.ts
@@ -11,9 +11,9 @@ const templateRoot = resolve(__dirname, "..", "dist", "templates");
 create("create-mud", {
   templateRoot,
   defaultTemplate: "vanilla",
-  // templates use pnpm workspaces, so default to that for now
+  // templates use yarn workspaces, so default to that for now
   // not sure if it's worth trying to support multiple kinds of package managers for monorepos, given the tooling is so different
-  defaultPackageManager: "pnpm",
+  defaultPackageManager: "yarn",
   promptForDescription: false,
   promptForAuthor: false,
   promptForEmail: false,

--- a/packages/network/src/createFastTxExecutor.ts
+++ b/packages/network/src/createFastTxExecutor.ts
@@ -49,6 +49,7 @@ export async function createFastTxExecutor(
       // Estimate gas if no gas limit was provided
       const gasLimit = overrides.gasLimit ?? (await contract.estimateGas[func as string].apply(null, args));
       console.log("gasLimit");
+      console.log(gasLimit);
 
       // Apply default overrides
       const fullOverrides = { type: 2, gasLimit, nonce: currentNonce.nonce++, ...gasConfig, ...overrides };

--- a/packages/solecs/src/BareComponent.sol
+++ b/packages/solecs/src/BareComponent.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { IWorld } from "./interfaces/IWorld.sol";
+import { IWorldCore } from "./interfaces/IWorldCore.sol";
 import { IComponent } from "./interfaces/IComponent.sol";
 
 import { Set } from "./Set.sol";
@@ -40,7 +40,7 @@ abstract contract BareComponent is IComponent, OwnableWritable {
    */
   function registerWorld(address _world) public onlyOwner {
     world = _world;
-    IWorld(world).registerComponent(address(this), id);
+    IWorldCore(world).registerComponent(address(this), id);
   }
 
   /**
@@ -109,7 +109,7 @@ abstract contract BareComponent is IComponent, OwnableWritable {
     entityToValue[entity] = value;
 
     // Emit global event
-    IWorld(world).registerComponentValueSet(entity, value);
+    IWorldCore(world).registerComponentValueSet(entity, value);
   }
 
   /**
@@ -124,6 +124,6 @@ abstract contract BareComponent is IComponent, OwnableWritable {
     delete entityToValue[entity];
 
     // Emit global event
-    IWorld(world).registerComponentValueRemoved(entity);
+    IWorldCore(world).registerComponentValueRemoved(entity);
   }
 }

--- a/packages/solecs/src/Component.sol
+++ b/packages/solecs/src/Component.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { IEntityIndexer } from "./interfaces/IEntityIndexer.sol";
-import { IWorld } from "./interfaces/IWorld.sol";
+import { IWorldCore } from "./interfaces/IWorldCore.sol";
 import { BareComponent } from "./BareComponent.sol";
 
 import { Set } from "./Set.sol";

--- a/packages/solecs/src/PayableSystem.sol
+++ b/packages/solecs/src/PayableSystem.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 
 import { IPayableSystem } from "./interfaces/IPayableSystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
-import { IWorld } from "./interfaces/IWorld.sol";
+import { IWorldCore } from "./interfaces/IWorldCore.sol";
 
 import { Ownable } from "./Ownable.sol";
 
@@ -12,9 +12,9 @@ import { Ownable } from "./Ownable.sol";
  */
 abstract contract PayableSystem is IPayableSystem, Ownable {
   IUint256Component components;
-  IWorld world;
+  IWorldCore world;
 
-  constructor(IWorld _world, address _components) {
+  constructor(IWorldCore _world, address _components) {
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
   }

--- a/packages/solecs/src/System.sol
+++ b/packages/solecs/src/System.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 
 import { ISystem } from "./interfaces/ISystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
-import { IWorld } from "./interfaces/IWorld.sol";
+import { IWorldCore } from "./interfaces/IWorldCore.sol";
 import { SystemStorage } from "./SystemStorage.sol";
 
 import { Ownable } from "./Ownable.sol";
@@ -13,9 +13,9 @@ import { Ownable } from "./Ownable.sol";
  */
 abstract contract System is ISystem, Ownable {
   IUint256Component components;
-  IWorld world;
+  IWorldCore world;
 
-  constructor(IWorld _world, address _components) {
+  constructor(IWorldCore _world, address _components) {
     // @deprecated use SystemStorage.components() instead of components
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     // @deprecated use SystemStorage.world() instead of world

--- a/packages/solecs/src/SystemStorage.sol
+++ b/packages/solecs/src/SystemStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
-import { IWorld } from "./interfaces/IWorld.sol";
+import { IWorldCore } from "./interfaces/IWorldCore.sol";
 import { getSystemAddressById, getAddressById } from "./utils.sol";
 
 /**
@@ -16,7 +16,7 @@ library SystemStorage {
   /** Data that the system stores */
   struct Layout {
     IUint256Component components;
-    IWorld world;
+    IWorldCore world;
   }
 
   /** Location in memory where the Layout struct will be stored */
@@ -39,7 +39,7 @@ library SystemStorage {
    * @param _components Address of the Components registry contract.
    * @dev This function must be called at the start of any contract that expects libraries to access SystemStorage!
    */
-  function init(IWorld _world, IUint256Component _components) internal {
+  function init(IWorldCore _world, IUint256Component _components) internal {
     Layout storage l = layout();
     l.world = _world;
     l.components = _components;
@@ -55,7 +55,7 @@ library SystemStorage {
   /**
    * @return World contract
    */
-  function world() public view returns (IWorld) {
+  function world() public view returns (IWorldCore) {
     return layout().world;
   }
 

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 
 import { Set } from "./Set.sol";
 import { LibQuery } from "./LibQuery.sol";
-import { IWorld, WorldQueryFragment } from "./interfaces/IWorld.sol";
+import { IWorldCore, WorldQueryFragment } from "./interfaces/IWorldCore.sol";
 import { QueryFragment } from "./interfaces/Query.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { Uint256Component } from "./components/Uint256Component.sol";
@@ -26,7 +26,7 @@ import { RegisterSystem, ID as registerSystemId, RegisterType } from "./systems/
  * Anyone can register new components and systems in the world (via the `registerComponent` and `registerSystem` methods).
  * Clients decide which components and systems they care about.
  */
-contract World is IWorld {
+contract World is IWorldCore {
   Set private entities = new Set();
   Uint256Component private _components;
   Uint256Component private _systems;

--- a/packages/solecs/src/interfaces/IWorldCore.sol
+++ b/packages/solecs/src/interfaces/IWorldCore.sol
@@ -13,7 +13,7 @@ struct WorldQueryFragment {
   bytes value;
 }
 
-interface IWorld {
+interface IWorldCore {
   function components() external view returns (IUint256Component);
 
   function systems() external view returns (IUint256Component);

--- a/packages/solecs/src/systems/RegisterSystem.sol
+++ b/packages/solecs/src/systems/RegisterSystem.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { ISystem } from "../interfaces/ISystem.sol";
-import { IWorld } from "../interfaces/IWorld.sol";
+import { IWorldCore } from "../interfaces/IWorldCore.sol";
 import { IERC173 } from "../interfaces/IERC173.sol";
 import { IUint256Component } from "../interfaces/IUint256Component.sol";
 import { addressToEntity, entityToAddress, getAddressById } from "../utils.sol";
@@ -17,7 +17,7 @@ enum RegisterType {
 uint256 constant ID = uint256(keccak256("world.system.register"));
 
 contract RegisterSystem is System {
-  constructor(IWorld _world, address _components) System(_world, _components) {}
+  constructor(IWorldCore _world, address _components) System(_world, _components) {}
 
   function requirement(bytes memory args) public view returns (bytes memory) {
     // TODO: Refactor to remove requirement/execute split

--- a/packages/solecs/src/test/System.t.sol
+++ b/packages/solecs/src/test/System.t.sol
@@ -4,12 +4,12 @@ pragma solidity >=0.8.0;
 import { DSTest } from "ds-test/test.sol";
 import { World } from "../World.sol";
 import { IUint256Component } from "../interfaces/IUint256Component.sol";
-import { IWorld } from "../interfaces/IWorld.sol";
+import { IWorldCore } from "../interfaces/IWorldCore.sol";
 import { SystemStorage } from "../SystemStorage.sol";
 import { System } from "../System.sol";
 
 contract SampleSystem is System {
-  constructor(IWorld _world, address _components) System(_world, _components) {}
+  constructor(IWorldCore _world, address _components) System(_world, _components) {}
 
   function execute(bytes memory arguments) public returns (bytes memory) {}
 
@@ -18,7 +18,7 @@ contract SampleSystem is System {
   }
 
   // Note: These two getter functions are necessary to access the vars of SampleSystem
-  function getWorld() public view returns (IWorld) {
+  function getWorld() public view returns (IWorldCore) {
     return world;
   }
 

--- a/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
+++ b/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
@@ -6,7 +6,7 @@ import { LibTypes } from "solecs/LibTypes.sol";
 import { BareComponent } from "solecs/BareComponent.sol";
 
 // imports for `executeSystemCallback` helper
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { ISystem } from "solecs/interfaces/ISystem.sol";
 import { getAddressById } from "solecs/utils.sol";
 
@@ -42,7 +42,7 @@ contract SystemCallbackBareComponent is BareComponent {
  * @dev Queries `world.systems()` for `cb.systemId`,
  * then executes the system with `cb.args`.
  */
-function executeSystemCallback(IWorld world, SystemCallback memory cb) returns (bytes memory) {
+function executeSystemCallback(IWorldCore world, SystemCallback memory cb) returns (bytes memory) {
   ISystem system = ISystem(getAddressById(world.systems(), cb.systemId));
   return system.execute(cb.args);
 }

--- a/packages/std-contracts/src/systems/BulkSetStateSystem.sol
+++ b/packages/std-contracts/src/systems/BulkSetStateSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "solecs/System.sol";
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { getAddressById, getSystemAddressById } from "solecs/utils.sol";
@@ -17,7 +17,7 @@ struct ECSEvent {
 }
 
 contract BulkSetStateSystem is System {
-  constructor(IWorld _world, address _components) System(_world, _components) {}
+  constructor(IWorldCore _world, address _components) System(_world, _components) {}
 
   function requirement(bytes memory) public view returns (bytes memory) {
     // NOTE: Make sure to not include this system in a production deployment, as anyone can change all component values

--- a/packages/std-contracts/src/systems/ComponentDevSystem.sol
+++ b/packages/std-contracts/src/systems/ComponentDevSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "solecs/System.sol";
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { getAddressById } from "solecs/utils.sol";
@@ -9,7 +9,7 @@ import { getAddressById } from "solecs/utils.sol";
 uint256 constant ID = uint256(keccak256("system.ComponentDev"));
 
 contract ComponentDevSystem is System {
-  constructor(IWorld _world, address _components) System(_world, _components) {}
+  constructor(IWorldCore _world, address _components) System(_world, _components) {}
 
   function requirement(bytes memory) public view returns (bytes memory) {
     // NOTE: Make sure to not include this system in a production deployment, as anyone can change all component values

--- a/packages/std-contracts/src/systems/UpgradableSystem.sol
+++ b/packages/std-contracts/src/systems/UpgradableSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "solecs/PayableSystem.sol";
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { getAddressById } from "solecs/utils.sol";
 import { AddressBareComponent } from "../components/AddressBareComponent.sol";
@@ -11,7 +11,7 @@ uint256 constant ID = uint256(keccak256("system.Upgradable"));
 contract UpgradableSystem is PayableSystem {
   address implementation;
 
-  constructor(IWorld _world, address _components) PayableSystem(_world, _components) {}
+  constructor(IWorldCore _world, address _components) PayableSystem(_world, _components) {}
 
   function execute(bytes memory args) public payable returns (bytes memory) {
     _delegate(implementation);

--- a/packages/std-contracts/src/test/MudTest.t.sol
+++ b/packages/std-contracts/src/test/MudTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { DSTest } from "ds-test/test.sol";
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { getAddressById } from "solecs/utils.sol";

--- a/packages/std-contracts/src/test/TestSystem.sol
+++ b/packages/std-contracts/src/test/TestSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IWorldCore } from "solecs/interfaces/IWorldCore.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { System } from "solecs/System.sol";
 import { getAddressById } from "solecs/utils.sol";
@@ -10,7 +10,7 @@ uint256 constant ID = uint256(keccak256("lib.testSystem"));
 
 /// @dev Sets values of `entities` to `newValues` for the component with `componentId`
 contract TestSystem is System {
-  constructor(IWorld _world, address _components) System(_world, _components) {}
+  constructor(IWorldCore _world, address _components) System(_world, _components) {}
 
   function execute(bytes memory args) public returns (bytes memory) {
     (uint256 componentId, uint256[] memory entities, bytes[] memory newValues) = abi.decode(


### PR DESCRIPTION
since there are two iworld interfaces in the code, foundry tris to disambiguate them by placing one of the iworld interfaces in `world/IWorld.sol/`. So I renamed all instances of IWorld.sol to IWorldCore so this clash wouldn't happen and the ABI that we do want (IWorld.sol) is generated at the top level of the out/ directory that foundry makes