### PR TITLE
estimate gas override

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -20,7 +20,7 @@ export const yDeployOptions = {
   estimateGas: {
     type: "boolean",
     desc: "Estimate gas required before deploying a contract. If false, a high gas estimate is used instead. Useful for deploying large contracts/STORE tables where you can't estimate gas.",
-    default: false,
+    default: true,
   },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
   disableTxWait: { type: "boolean", desc: "Disable waiting for transactions to be confirmed.", default: false },

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -17,6 +17,11 @@ export const yDeployOptions = {
   rpc: { type: "string", desc: "The RPC URL to use. Defaults to the RPC url from the local foundry.toml" },
   worldAddress: { type: "string", desc: "Deploy to an existing World at the given address" },
   createNamespace: { type: "boolean", desc: "Create and deploy to a new namespace", default: true },
+  estimateGas: {
+    type: "boolean",
+    desc: "Estimate gas required before deploying a contract. If false, a high gas estimate is used instead. Useful for deploying large contracts/STORE tables where you can't estimate gas.",
+    default: false,
+  },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
   disableTxWait: { type: "boolean", desc: "Disable waiting for transactions to be confirmed.", default: false },
   pollInterval: {

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -163,6 +163,7 @@ const commandModule: CommandModule<Options, Options> = {
         configPath,
         skipBuild: true,
         createNamespace: true,
+        estimateGas: false,
         priorityFeeMultiplier: 1,
         disableTxWait: true,
         pollInterval: 1000,

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -163,7 +163,7 @@ const commandModule: CommandModule<Options, Options> = {
         configPath,
         skipBuild: true,
         createNamespace: true,
-        estimateGas: false,
+        estimateGas: true,
         priorityFeeMultiplier: 1,
         disableTxWait: true,
         pollInterval: 1000,

--- a/packages/cli/src/utils/deployHandler.ts
+++ b/packages/cli/src/utils/deployHandler.ts
@@ -21,6 +21,7 @@ export type DeployOptions = {
   rpc?: string;
   worldAddress?: string;
   createNamespace: boolean;
+  estimateGas: boolean;
   srcDir?: string;
   disableTxWait: boolean;
   pollInterval: number;

--- a/packages/world/ts/node/render-solidity/worldgen.ts
+++ b/packages/world/ts/node/render-solidity/worldgen.ts
@@ -22,7 +22,7 @@ export async function worldgen(
   const systemInterfaceImports: RelativeImportDatum[] = [];
   for (const system of systems) {
     const data = readFileSync(system.path, "utf8");
-    // get external funcions from a contract
+    // get external functions from a contract
     const { functions, errors, symbolImports } = contractToInterface(data, system.basename);
     const imports = symbolImports.map((symbolImport) => {
       if (symbolImport.path[0] === ".") {


### PR DESCRIPTION
- Since we are deploying large tables, the estimate gas function fails. So we added this override so we can deploy the large tables