### PR TITLE
feat: fix estimate gas default val

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -20,7 +20,7 @@ export const yDeployOptions = {
   estimateGas: {
     type: "boolean",
     desc: "Estimate gas required before deploying a contract. If false, a high gas estimate is used instead. Useful for deploying large contracts/STORE tables where you can't estimate gas.",
-    default: true,
+    default: false,
   },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
   disableTxWait: { type: "boolean", desc: "Disable waiting for transactions to be confirmed.", default: false },

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -163,7 +163,7 @@ const commandModule: CommandModule<Options, Options> = {
         configPath,
         skipBuild: true,
         createNamespace: true,
-        estimateGas: true,
+        estimateGas: false,
         priorityFeeMultiplier: 1,
         disableTxWait: true,
         pollInterval: 1000,


### PR DESCRIPTION
- revert change to always NOT estimate gas for simplicity. I didn't want to go hunting for where to set this flag in the code