### PR TITLE
fix(world): snapsync incorrect index for records

### DIFF
--- a/packages/world/src/modules/snapsync/SnapSyncSystem.sol
+++ b/packages/world/src/modules/snapsync/SnapSyncSystem.sol
@@ -41,7 +41,7 @@ contract SnapSyncSystem is System {
       }
 
       bytes memory value = StoreSwitch.getRecord(tableId, keyTuple);
-      records[i] = SyncRecord({ tableId: tableId, keyTuple: keyTuple, value: value });
+      records[i - offset] = SyncRecord({ tableId: tableId, keyTuple: keyTuple, value: value });
     }
   }
 

--- a/packages/world/test/SnapSyncModule.t.sol
+++ b/packages/world/test/SnapSyncModule.t.sol
@@ -121,6 +121,32 @@ contract SnapSyncModuleTest is Test, GasReporter {
     testSnapSync(val1, val2);
   }
 
+  function testSnapSyncWithOffset(uint256 value1, uint256 value2) public {
+    _installModules();
+
+    // Set some values in the source table
+    world.setRecord(namespace, name, keyTuple1, abi.encodePacked(value1));
+    world.setRecord(namespace, name, keyTuple2, abi.encodePacked(value2));
+
+    startGasReport("Call snap sync on a table with 2 records, limit 1 and offset 0");
+    SyncRecord[] memory records = ISnapSyncSystem(address(world)).snapSync_system_getRecords(tableId, 1, 0);
+    endGasReport();
+
+    // Assert that the list is correct
+    assertEq(records.length, 1);
+    assertEq(records[0].keyTuple[0], key1);
+    assertEq(records[0].value, abi.encodePacked(value1));
+
+    startGasReport("Call snap sync on a table with 2 records, limit 1 and offset 1");
+    records = ISnapSyncSystem(address(world)).snapSync_system_getRecords(tableId, 1, 1);
+    endGasReport();
+
+    // Assert that the list is correct
+    assertEq(records.length, 1);
+    assertEq(records[0].keyTuple[0], key2);
+    assertEq(records[0].value, abi.encodePacked(value2));
+  }
+
   function testSnapSyncComposite(uint256 value1, uint256 value2) public {
     _installModules();
 


### PR DESCRIPTION
The function `getRecords()` in `SnapSyncSystem` populates the `records` array with elements from the specified table, starting from a specified offset.

The for loop's index (`i`) is for the table's records (ie with an offset), but the index to populate `records` should be from 0 (ie without an offset). Currently, it's including the offset. This causes an out of bounds error.

Found the bug when running [getSnapSyncRecords](https://github.com/latticexyz/mud/blob/main/packages/network/src/v2/snapSync/getSnapSyncRecords.ts#L15) from the client which uses an offset after a table has 100 keys.

Also, added a test that uses an offset.