### PR TITLE
add the nonceManager to the world contract so we can update it

### DIFF
--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -1,3 +1,4 @@
+import pRetry from "p-retry";
 import {
   Abi,
   Account,
@@ -13,7 +14,6 @@ import {
   WriteContractParameters,
   getContract,
 } from "viem";
-import pRetry from "p-retry";
 import { createNonceManager } from "./createNonceManager";
 import { debug as parentDebug } from "./debug";
 import { UnionOmit } from "./type-utils/common";
@@ -86,6 +86,7 @@ export function createContract<
       publicClient: publicClient as PublicClient,
       address: walletClient.account.address,
     });
+    contract.nonceManager = nonceManager;
 
     // Replace write calls with our own proxy. Implemented ~the same as viem, but adds better handling of nonces (via queue + retries).
     contract.write = new Proxy(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       rxjs:
-        specifier: 7.5.5
-        version: 7.5.5
+        specifier: 7.8.1
+        version: 7.8.1
       viem:
         specifier: 1.6.0
         version: 1.6.0(typescript@5.1.6)(zod@3.21.4)


### PR DESCRIPTION
- when we call viem functions with our burner wallet (e.g. deploy a codegened contract, the nonce in the worldContract is not updated. So we expose the nonceManager to allow us to manually increment the nonce (so subsequent system calls will have the proper nonce number)