### PR TITLE
expose noncemanager

### DIFF
--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -86,6 +86,7 @@ export function createContract<
       publicClient: publicClient as PublicClient,
       address: walletClient.account.address,
     });
+    contract.nonceManager = nonceManager;
 
     // Replace write calls with our own proxy. Implemented ~the same as viem, but adds better handling of nonces (via queue + retries).
     contract.write = new Proxy(


### PR DESCRIPTION
when we call viem functions with our burner wallet (e.g. when we deploy a codegened contract), the nonce in the worldContract is not updated. So we expose the nonceManager to allow us to manually increment the nonce (so subsequent system calls will have the proper nonce number)